### PR TITLE
Use masonry from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "url": "git+https://github.com/shershen08/vue-masonry.git"
   },
   "dependencies": {
-    "vue": "^2.0.0",
+    "imagesloaded": "latest",
     "masonry": "latest",
-    "imagesloaded": "latest"
+    "masonry-layout": "4.1.1",
+    "vue": "^2.0.0"
   },
   "keywords": [
     "masonry",

--- a/src/masonry.plugin.js
+++ b/src/masonry.plugin.js
@@ -1,4 +1,6 @@
  import Vue from 'vue'
+ import Masonry from 'masonry-layout';
+
  const attributesMap = {
    'column-width': 'columnWidth',
    'transition-duration': 'transitionDuration',


### PR DESCRIPTION
Thought it would be nice to use masonry from npm package instead of using cdn. What do you think?

Great library by the way!