### PR TITLE
Add support for stagger settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Properties that are currently available reproduce most of those on the [original
  (https://masonry.desandro.com/options.html#gutter). Set gutter to an Element or Selector String to use the outer width of the element.
  - ```fit-width="true"``` - sets the width of the container to fit the available number of columns
  - ```horizontal-order="true"``` - lays out items to (mostly) maintain horizontal left-to-right order
+ - ```stagger="0.03s"``` - Staggers item transitions, so items transition incrementally after one another. Set as a CSS time format, '0.03s', or as a number in milliseconds, 30
 
 
 💡💡💡 If you need to manually trigger masonry layout redraw (for example in case if your tile elements amount or content has changed) you can now use `this.$redrawVueMasonry()` method. (If you use **old version** `< 0.10.11` it can still be `Vue.redrawVueMasonry()`, but please consider to upgrade)

--- a/src/masonry.plugin.js
+++ b/src/masonry.plugin.js
@@ -11,7 +11,8 @@ const attributesMap = {
   'stamp': 'stamp',
   'gutter': 'gutter',
   'percent-position': 'percentPosition',
-  'horizontal-order': 'horizontalOrder'
+  'horizontal-order': 'horizontalOrder',
+  'stagger': 'stagger'
 }
 const EVENT_ADD = 'vuemasonry.itemAdded'
 const EVENT_REMOVE = 'vuemasonry.itemRemoved'


### PR DESCRIPTION
Add support for stagger settings.
Documention: https://masonry.desandro.com/options.html#stagger
Use like this:
`<div class="masonry-grid"
      v-masonry
      transition-duration="1s"
      item-selector=".grid-item"
      column-width=".grid-sizer"
      :stagger="stagger"
    >
  …
  …
export default {
  data () {
    return {
      stagger: 100
  …
`
or use like other attributes:
`<div class="masonry-grid"
      v-masonry
      transition-duration="1s"
      item-selector=".grid-item"
      column-width=".grid-sizer"
      stagger="100"
    >
  …
  …
`