### PR TITLE
Add Tailwind CSS Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Vue.js directive for masonry blocks layouting. Original [masonry library](http:/
 
 Plugin [DEMO](https://shershen08.github.io/vue-plugins-demo-static/index.html#/masonry) available 🎉, [JSFiddle DEMO](https://jsfiddle.net/jericopulvera/wq07brjs)
 
+The plugin can be easily integrated with different CSS Frameworks. Check this [Tailwind CSS DEMO](https://jsbin.com/zafegay/edit?html,output).
+
 You can also clone the basic demo repository [vue-masonry + vue-cli webpack](https://github.com/shershen08/vue-masonry-plugin-demo).
 
 ## Usage


### PR DESCRIPTION
This PR ads a link to the Tailwind CSS demo, as mentioned on https://github.com/shershen08/vue-masonry/issues/96.