### PR TITLE
updating nextThink issue for vue 3 and vite

### DIFF
--- a/src/masonry-vue3.plugin.js
+++ b/src/masonry-vue3.plugin.js
@@ -2,7 +2,7 @@ import Masonry from 'masonry-layout'
 import ImageLoaded from 'imagesloaded'
 
 // Vue 3 Global API changed: nextTick import
-import { nextTick } from 'vue';
+import Vue from 'vue';
 
 const attributesMap = {
   'column-width': 'columnWidth',
@@ -69,7 +69,7 @@ export class VueMasonryPlugin {
         }
 
         // Updated nextTick method
-        nextTick(() => {
+        Vue.nextTick(() => {
           masonryDraw()
         })
 


### PR DESCRIPTION
When I tried using this plugin with vue 3 and vite, I got error because of nextThink.

If we change like this `import Vue from 'vue'` instead of this `import { nextThink } from 'vue'` and we update this `nextThink()` to this `Vue.nextThink()` it works fine without any error.